### PR TITLE
Fixes university name state on application form

### DIFF
--- a/src/app/apply/application-form.tsx
+++ b/src/app/apply/application-form.tsx
@@ -78,7 +78,7 @@ export default function ApplicationForm({
     countries.all.find((c) => c.alpha2 === user.country),
   );
   const [university, setUniversity] = useState<University | undefined>(
-    universities.find((u) => u.name === user.university_name || u.name === "University of Edinburgh"),
+    universities.find((u) => u.name === user.university_name) || universities.find((u) => u.name === "University of Edinburgh"),
   );
   const [universityYear, setUniversityYear] = useState(
     user.university_year ?? undefined,


### PR DESCRIPTION
Application form shows UoE for some users when they reload the application form, despite the users filled in with another uni

Affected pages are
- University form
- University email form
- Review application page

![image](https://github.com/user-attachments/assets/eda2c16b-d3b9-47bc-abae-8676d89aac72)
