### PR TITLE
Fix domain lookup

### DIFF
--- a/src/app/apply/_steps/email.tsx
+++ b/src/app/apply/_steps/email.tsx
@@ -88,7 +88,7 @@ export default function EmailStep({
 
   const isUniEmail = (e = email) => {
     const domain = e?.split("@")[1] as string;
-    return university?.domains.includes(domain);
+    return university?.domains?.some((d) => domain.endsWith(d));
   };
 
   return (


### PR DESCRIPTION
No checks for the suffix of domain matching something in the university list instead of an exact match on the whole domain.

Allows for emails like student.manchester.ac.uk to still pass the check